### PR TITLE
Storing OAuth User in Cookies

### DIFF
--- a/auth/auth.go
+++ b/auth/auth.go
@@ -1,9 +1,14 @@
 package auth
 
 import (
+	"fmt"
+	"log"
+	"net/http"
 	"os"
 
+	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
+	"github.com/markbates/goth/gothic"
 	"github.com/markbates/goth/providers/google"
 )
 
@@ -16,4 +21,46 @@ func InitOAuth2() {
 			os.Getenv("GOOGLE_REDIRECT_URL"),
 		),
 	)
+	gothic.Store = sessions.NewCookieStore([]byte(os.Getenv("SESSION_SECRET")))
+}
+
+func GetSessionUser(r *http.Request) (goth.User, error) {
+	session, err := gothic.Store.Get(r, "session")
+	if err != nil {
+		return goth.User{}, err
+	}
+
+	u := session.Values["user"]
+	if u == nil {
+		return goth.User{}, fmt.Errorf("user is not authenticated! %v", u)
+	}
+	return u.(goth.User), nil
+}
+
+func StoreUserSession(w http.ResponseWriter, r *http.Request, user goth.User) error {
+	// Get a session. We're ignoring the error resulted from decoding an
+	// existing session: Get() always reutnrs a session, even if empty.
+	session, _ := gothic.Store.Get(r, "session")
+	session.Values["user"] = user
+	err := session.Save(r, w)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return err
+	}
+	return nil
+}
+
+func RequireAuth(handlerFunc http.HandlerFunc) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		session, err := GetSessionUser(r)
+		if err != nil {
+			log.Println("User is not authenticated!")
+			http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
+			return
+		}
+
+		log.Printf("user is authenticated! user: %v!", session.FirstName)
+
+		handlerFunc(w, r)
+	}
 }

--- a/auth/auth.go
+++ b/auth/auth.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/gin-gonic/gin"
 	"github.com/gorilla/sessions"
 	"github.com/markbates/goth"
 	"github.com/markbates/goth/gothic"
@@ -50,17 +51,16 @@ func StoreUserSession(w http.ResponseWriter, r *http.Request, user goth.User) er
 	return nil
 }
 
-func RequireAuth(handlerFunc http.HandlerFunc) http.HandlerFunc {
-	return func(w http.ResponseWriter, r *http.Request) {
-		session, err := GetSessionUser(r)
+func RequireAuth(handlerFunc gin.HandlerFunc) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		session, err := GetSessionUser(c.Request)
 		if err != nil {
 			log.Println("User is not authenticated!")
-			http.Redirect(w, r, "/login", http.StatusTemporaryRedirect)
 			return
 		}
 
 		log.Printf("user is authenticated! user: %v!", session.FirstName)
 
-		handlerFunc(w, r)
+		handlerFunc(c)
 	}
 }

--- a/routes/routes.go
+++ b/routes/routes.go
@@ -1,6 +1,7 @@
 package routes
 
 import (
+	"meals/auth"
 	"meals/handlers"
 
 	"github.com/gin-gonic/gin"
@@ -8,7 +9,7 @@ import (
 
 func RegisterRoutes(router *gin.Engine) {
 	// Home
-	router.GET("/", handlers.HomeHandler)
+	router.GET("/", auth.RequireAuth(handlers.HomeHandler))
 
 	// Auth
 	router.GET("/auth/:provider", handlers.GetAuthProviderHandler)


### PR DESCRIPTION
Included wrapper functionality for gin context requests, so that if they require authentication they can be accurately treated as such.